### PR TITLE
#31 Conjugations are no longer clickable

### DIFF
--- a/app/src/main/java/com/a494studios/koreanconjugator/display/adapters/FavoritesAdapter.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/display/adapters/FavoritesAdapter.java
@@ -50,7 +50,7 @@ public class FavoritesAdapter extends BaseAdapter {
     }
 
     @Override
-    public Object getItem(int i) {
+    public Map.Entry<String,ConjugationQuery.Conjugation> getItem(int i) {
         return entries.get(i);
     }
 

--- a/app/src/main/java/com/a494studios/koreanconjugator/display/cards/ConjugationCard.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/display/cards/ConjugationCard.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.a494studios.koreanconjugator.CustomApplication;
 import com.a494studios.koreanconjugator.display.ConjInfoActivity;
 import com.a494studios.koreanconjugator.display.adapters.ConjugationAdapter;
 import com.a494studios.koreanconjugator.ConjugationQuery;
@@ -44,23 +43,20 @@ public class ConjugationCard implements DisplayCardBody {
         }
         LinearListView listView = view.findViewById(R.id.listCard_list);
         listView.setAdapter(adapter);
-        listView.setOnItemClickListener(new LinearListView.OnItemClickListener() {
-            @Override
-            public void onItemClick(LinearListView parent, View view, int position, long id) {
-                ConjugationQuery.Conjugation conjugation = adapter.getItem(position);
+        listView.setOnItemClickListener((parent, view, position, id) -> {
+            ConjugationQuery.Conjugation conjugation = adapter.getItem(position);
 
-                // Log select conjugation event
-                Logger.getInstance().logSelectConjugation(term, pos, conjugation.name());
+            // Log select conjugation event
+            Logger.getInstance().logSelectConjugation(term, pos, conjugation.name());
 
-                Intent i = new Intent(view.getContext(), ConjInfoActivity.class);
-                i.putExtra(ConjInfoActivity.EXTRA_NAME, conjugation.name());
-                i.putExtra(ConjInfoActivity.EXTRA_CONJ,conjugation.conjugation());
-                i.putExtra(ConjInfoActivity.EXTRA_PRON,conjugation.pronunciation());
-                i.putExtra(ConjInfoActivity.EXTRA_ROME,conjugation.romanization());
-                i.putExtra(ConjInfoActivity.EXTRA_EXPL,new ArrayList<>(conjugation.reasons()));
-                i.putExtra(ConjInfoActivity.EXTRA_HONO, conjugation.honorific());
-                view.getContext().startActivity(i);
-            }
+            Intent i = new Intent(view.getContext(), ConjInfoActivity.class);
+            i.putExtra(ConjInfoActivity.EXTRA_NAME, conjugation.name());
+            i.putExtra(ConjInfoActivity.EXTRA_CONJ,conjugation.conjugation());
+            i.putExtra(ConjInfoActivity.EXTRA_PRON,conjugation.pronunciation());
+            i.putExtra(ConjInfoActivity.EXTRA_ROME,conjugation.romanization());
+            i.putExtra(ConjInfoActivity.EXTRA_EXPL,new ArrayList<>(conjugation.reasons()));
+            i.putExtra(ConjInfoActivity.EXTRA_HONO, conjugation.honorific());
+            view.getContext().startActivity(i);
         });
         return view;
     }

--- a/app/src/main/java/com/a494studios/koreanconjugator/display/cards/FavoritesCard.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/display/cards/FavoritesCard.java
@@ -8,7 +8,9 @@ import android.view.ViewGroup;
 import com.a494studios.koreanconjugator.conjugations.ConjugationActivity;
 import com.a494studios.koreanconjugator.ConjugationQuery;
 import com.a494studios.koreanconjugator.R;
+import com.a494studios.koreanconjugator.display.ConjInfoActivity;
 import com.a494studios.koreanconjugator.display.adapters.FavoritesAdapter;
+import com.a494studios.koreanconjugator.utils.Logger;
 import com.linearlistview.LinearListView;
 
 import java.util.ArrayList;
@@ -40,6 +42,22 @@ public class FavoritesCard implements DisplayCardBody {
         }
         LinearListView listView = view.findViewById(R.id.listCard_list);
         listView.setAdapter(adapter);
+        listView.setOnItemClickListener((parent, view, position, id) -> {
+            String favName = adapter.getItem(position).getKey();
+            ConjugationQuery.Conjugation conjugation = adapter.getItem(position).getValue();
+
+            // Log select favorite event
+            Logger.getInstance().logSelectFavorite(favName, conjugation.name(), conjugation.conjugation());
+
+            Intent i = new Intent(view.getContext(), ConjInfoActivity.class);
+            i.putExtra(ConjInfoActivity.EXTRA_NAME, conjugation.name());
+            i.putExtra(ConjInfoActivity.EXTRA_CONJ,conjugation.conjugation());
+            i.putExtra(ConjInfoActivity.EXTRA_PRON,conjugation.pronunciation());
+            i.putExtra(ConjInfoActivity.EXTRA_ROME,conjugation.romanization());
+            i.putExtra(ConjInfoActivity.EXTRA_EXPL,new ArrayList<>(conjugation.reasons()));
+            i.putExtra(ConjInfoActivity.EXTRA_HONO, conjugation.honorific());
+            view.getContext().startActivity(i);
+        });
         return view;
     }
 

--- a/app/src/main/java/com/a494studios/koreanconjugator/utils/Logger.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/utils/Logger.java
@@ -9,6 +9,7 @@ public class Logger {
     private static final String EVENT_SELECT_CONJ = "select_conjugation";
     private static final String EVENT_VIEW_UPGRADE = "view_upgrade";
     private static final String EVENT_ADD_FAVORITE = "add_favorite";
+    private static final String EVENT_SELECT_FAV = "select_fav";
 
     private FirebaseAnalytics mFirebaseAnalytics;
     private static Logger logger;
@@ -61,6 +62,14 @@ public class Logger {
         bundle.putString("conjugation", conjugation);
         bundle.putBoolean("is_honorific", honorific);
         mFirebaseAnalytics.logEvent(EVENT_ADD_FAVORITE, bundle);
+    }
+
+    public void logSelectFavorite(String favName, String conjugation, String conjugated) {
+        Bundle bundle = new Bundle();
+        bundle.putString("favorite_name", favName);
+        bundle.putString("conjugation", conjugation);
+        bundle.putString("conjugated", conjugated);
+        mFirebaseAnalytics.logEvent(EVENT_SELECT_FAV, bundle);
     }
 
     private String detectLanguage(String term){

--- a/app/src/main/res/layout/item_conjugation.xml
+++ b/app/src/main/res/layout/item_conjugation.xml
@@ -6,7 +6,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:paddingTop="8dp"
     android:orientation="horizontal"
-    android:background="?attr/selectableItemBackground">
+    android:background="?android:attr/selectableItemBackground">
 
     <TextView
         android:id="@+id/conjFormal"
@@ -19,7 +19,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="24sp"
-        tools:text=":"/>
+        android:text="@string/conj_seperator"/>
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/conjText"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/item_conjugation.xml
+++ b/app/src/main/res/layout/item_conjugation.xml
@@ -3,8 +3,10 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:paddingTop="8dp"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    android:background="?attr/selectableItemBackground">
 
     <TextView
         android:id="@+id/conjFormal"
@@ -12,24 +14,21 @@
         android:layout_height="wrap_content"
         android:layout_weight="0.5"
         android:textSize="24sp"
-        android:text="Informal low"
-        android:textIsSelectable="true"/>
+        tools:text="Informal low"/>
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="24sp"
-        android:text=":"/>
+        tools:text=":"/>
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/conjText"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginStart="10dp"
-        android:layout_marginLeft="10dp"
         android:layout_weight="0.5"
         android:textSize="24sp"
-        android:text="갈 거예요"
+        tools:text="갈 거예요"
         android:maxLines="1"
-        android:textIsSelectable="true"
         app:autoSizeTextType="uniform"
         app:autoSizeMaxTextSize="24sp"/>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,4 +48,5 @@
     <string name="honorific_forms">Honorific Forms</string>
     <string name="regular_forms">Regular Forms</string>
     <string name="menu_ad_free">Remove Ads</string>
+    <string name="conj_seperator">:</string>
 </resources>


### PR DESCRIPTION
Closes #31 . Decided to make conjugations in a conjugation card not selectable. Making a view both clickable and selectable can open up a lot of bugs and probably isn't good UX. Additionally, the conjugation can be copied from ConjInfo Activity, so the user doesn't lose anything.

Also added a selectable background to make a conjugation's clickable-ness obvious and made favorite card conjugations clickable.