### PR TITLE
#26 Conjugator option only shows for Korean searches

### DIFF
--- a/app/src/main/java/com/a494studios/koreanconjugator/search/NoResultsFragment.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/search/NoResultsFragment.java
@@ -11,6 +11,7 @@ import androidx.fragment.app.DialogFragment;
 
 import com.a494studios.koreanconjugator.R;
 import com.a494studios.koreanconjugator.conjugator.ConjugatorActivity;
+import com.a494studios.koreanconjugator.utils.Utils;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -42,8 +43,20 @@ public class NoResultsFragment extends DialogFragment implements DialogInterface
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         String title = getString(R.string.no_results_title);
-        String msg = getString(R.string.no_results_msg);
+        String msg = getString(R.string.no_results_msg_eng);
         String searchTerm = getArguments().getString(ARG_SEARCH_TERM);
+
+        // Change message and add Conjugator option
+        if(Utils.isHangul(searchTerm)) {
+            msg = getString(R.string.no_results_msg_kor);
+
+            String okBtnText = getResources().getString(R.string.no_results_positive_btn);
+            builder.setPositiveButton(okBtnText, (dialogInterface, i) -> {
+                Intent intent = new Intent(getContext(), ConjugatorActivity.class);
+                intent.putExtra(ConjugatorActivity.EXTRA_TERM, searchTerm);
+                startActivity(intent);
+            });
+        }
 
         builder.setTitle(title);
         builder.setMessage(msg);
@@ -54,13 +67,6 @@ public class NoResultsFragment extends DialogFragment implements DialogInterface
         } else {
             builder.setNegativeButton(cancelBtnText,this);
         }
-
-        String okBtnText = getResources().getString(R.string.no_results_positive_btn);
-        builder.setPositiveButton(okBtnText, (dialogInterface, i) -> {
-            Intent intent = new Intent(getContext(), ConjugatorActivity.class);
-            intent.putExtra(ConjugatorActivity.EXTRA_TERM, searchTerm);
-            startActivity(intent);
-        });
 
         return builder.create();
     }

--- a/app/src/main/java/com/a494studios/koreanconjugator/utils/Utils.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/utils/Utils.java
@@ -27,7 +27,6 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
-import com.mikepenz.aboutlibraries.Libs;
 import com.mikepenz.aboutlibraries.LibsBuilder;
 
 import org.rm3l.maoni.Maoni;
@@ -232,5 +231,20 @@ public class Utils {
                 .beginTransaction()
                 .add(fragment,"frag_alert")
                 .commitAllowingStateLoss();
+    }
+
+    public static boolean isHangul(String korean){
+        if(korean.isEmpty()){
+            return false;
+        }
+
+        korean = korean.replace(" ","");
+        for(int i=0;i<korean.length();i++){
+            char c = korean.charAt(i);
+            if(!((int)c >= '가' && (int)c <= '힣')){
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,7 +18,8 @@
     <string name="logo_text">한지 |Hanji</string>
     <!--Error Messages-->
     <string name="no_results_title">No Results</string>
-    <string name="no_results_msg">We couldn\'t find anything matching your search. You can use the conjugator, but the conjugations might not be accurate.</string>
+    <string name="no_results_msg_eng">We couldn\'t find anything matching your search.</string>
+    <string name="no_results_msg_kor">We couldn\'t find anything matching your search. You can use the conjugator, but the conjugations might not be accurate.</string>
     <string name="no_results_positive_btn">Use Conjugator</string>
     <!--Feedback Strings-->
     <string name="feed_title">How are you enjoying our app?</string>

--- a/app/src/test/java/com/a494studios/koreanconjugator/search/NoResultsFragmentUnitTest.java
+++ b/app/src/test/java/com/a494studios/koreanconjugator/search/NoResultsFragmentUnitTest.java
@@ -11,7 +11,6 @@ import android.widget.TextView;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
-import androidx.test.espresso.matcher.ViewMatchers;
 
 import com.a494studios.koreanconjugator.conjugator.ConjugatorActivity;
 
@@ -23,7 +22,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.Shadows;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyObject;
@@ -45,7 +43,7 @@ public class NoResultsFragmentUnitTest {
     }
 
     @Test
-    public void test_correctTextKorean() {
+    public void view_correctWhenSearchKorean() {
         String term = "가다";
         DialogInterface.OnClickListener listener = mock(DialogInterface.OnClickListener.class);
         NoResultsFragment fragment = NoResultsFragment.newInstance(term, listener);
@@ -77,7 +75,7 @@ public class NoResultsFragmentUnitTest {
     }
 
     @Test
-    public void test_correctTextEnglish() {
+    public void view_correctWhenSearchEnglish() {
         NoResultsFragment fragment = NoResultsFragment.newInstance("english", null);
         FragmentManager fragmentManager = activity.getSupportFragmentManager();
         fragment.show(fragmentManager, "tag");
@@ -100,7 +98,7 @@ public class NoResultsFragmentUnitTest {
     }
 
     @Test
-    public void test_cancelBtn() {
+    public void cancelBtn_works() {
         DialogInterface.OnClickListener listener = mock(DialogInterface.OnClickListener.class);
         NoResultsFragment fragment = NoResultsFragment.newInstance("term", listener);
 

--- a/app/src/test/java/com/a494studios/koreanconjugator/search/NoResultsFragmentUnitTest.java
+++ b/app/src/test/java/com/a494studios/koreanconjugator/search/NoResultsFragmentUnitTest.java
@@ -4,12 +4,14 @@ import android.app.Dialog;
 import android.content.ComponentName;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
+import androidx.test.espresso.matcher.ViewMatchers;
 
 import com.a494studios.koreanconjugator.conjugator.ConjugatorActivity;
 
@@ -21,6 +23,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.Shadows;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyObject;
@@ -30,13 +33,10 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
 public class NoResultsFragmentUnitTest {
-
-    private NoResultsFragment fragment;
     private FragmentActivity activity;
 
     @Before
     public void init() {
-        fragment =  NoResultsFragment.newInstance("term", null);
         activity = Robolectric.buildActivity(FragmentActivity.class)
                 .create()
                 .start()
@@ -45,21 +45,58 @@ public class NoResultsFragmentUnitTest {
     }
 
     @Test
-    public void test_correctText() {
+    public void test_correctTextKorean() {
+        String term = "가다";
+        DialogInterface.OnClickListener listener = mock(DialogInterface.OnClickListener.class);
+        NoResultsFragment fragment = NoResultsFragment.newInstance(term, listener);
+
         FragmentManager fragmentManager = activity.getSupportFragmentManager();
         fragment.show(fragmentManager, "tag");
 
-        Dialog dialog = fragment.getDialog();
+        AlertDialog dialog = (AlertDialog)fragment.getDialog();
 
         assertTrue(dialog.isShowing());
 
         int titleId = activity.getResources().getIdentifier( "alertTitle", "id", activity.getPackageName() );
-
         TextView titleView = dialog.findViewById(titleId);
         TextView msgView = dialog.findViewById(android.R.id.message);
 
         assertEquals(titleView.getText(), "No Results");
         assertEquals(msgView.getText(), "We couldn't find anything matching your search. You can use the conjugator, but the conjugations might not be accurate.");
+
+        // Check Conjugator option
+        Button btn = dialog.getButton(Dialog.BUTTON_POSITIVE);
+        btn.performClick();
+
+        assertEquals(btn.getText(), "Use Conjugator");
+
+        Intent intent = Shadows.shadowOf(activity).peekNextStartedActivityForResult().intent;
+
+        assertEquals(intent.getComponent(), new ComponentName(activity, ConjugatorActivity.class));
+        assertEquals(intent.getStringExtra(ConjugatorActivity.EXTRA_TERM), term);
+    }
+
+    @Test
+    public void test_correctTextEnglish() {
+        NoResultsFragment fragment = NoResultsFragment.newInstance("english", null);
+        FragmentManager fragmentManager = activity.getSupportFragmentManager();
+        fragment.show(fragmentManager, "tag");
+
+        AlertDialog dialog = (AlertDialog)fragment.getDialog();
+
+        assertTrue(dialog.isShowing());
+
+        int titleId = activity.getResources().getIdentifier( "alertTitle", "id", activity.getPackageName());
+        TextView titleView = dialog.findViewById(titleId);
+        TextView msgView = dialog.findViewById(android.R.id.message);
+
+        assertEquals(titleView.getText(), "No Results");
+        assertEquals(msgView.getText(), "We couldn't find anything matching your search.");
+
+        // Conjugator option shouldn't be present
+        Button btn = dialog.getButton(Dialog.BUTTON_POSITIVE);
+
+        assertEquals(btn.getVisibility(), View.GONE);
     }
 
     @Test
@@ -80,28 +117,5 @@ public class NoResultsFragmentUnitTest {
 
         // listener is called a second time when dismissed by test runner
         verify(listener, times(2)).onClick(anyObject(), anyInt());
-    }
-
-    @Test
-    public void test_okBtn() {
-        String term = "term";
-        DialogInterface.OnClickListener listener = mock(DialogInterface.OnClickListener.class);
-        NoResultsFragment fragment = NoResultsFragment.newInstance(term, listener);
-
-        fragment.show(activity.getSupportFragmentManager(), "tag");
-
-        AlertDialog dialog = (AlertDialog)fragment.getDialog();
-
-        assertTrue(dialog.isShowing());
-
-        Button btn = dialog.getButton(Dialog.BUTTON_POSITIVE);
-        btn.performClick();
-
-        assertEquals(btn.getText(), "Use Conjugator");
-
-        Intent intent = Shadows.shadowOf(activity).peekNextStartedActivityForResult().intent;
-
-        assertEquals(intent.getComponent(), new ComponentName(activity, ConjugatorActivity.class));
-        assertEquals(intent.getStringExtra(ConjugatorActivity.EXTRA_TERM), term);
     }
 }


### PR DESCRIPTION
Closes #26 . Used the `isHangul` method from 1.0 to only show the Conjugator option for Korean language searches.