### PR TITLE
#39 Dialog buttons in Favorites Activity are the wrong color

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -9,6 +9,7 @@
         <item name="colorSecondary">@color/colorAccent</item>
         <item name="popupMenuStyle">@style/OverflowMenuStyle</item>
         <item name="colorSurface">@color/white</item>
+        <item name="alertDialogTheme">@style/AlertDialogTheme</item>
     </style>
 
     <style name="AppTheme.NoTransition" parent="AppTheme">
@@ -49,6 +50,10 @@
 
     <style name="OutlinedButton" parent="Widget.AppCompat.Button.Borderless.Colored">
         <item name="android:textColor">@color/button_color</item>
+    </style>
+
+    <style name="AlertDialogTheme" parent="ThemeOverlay.MaterialComponents.Dialog.Alert">
+        <item name="colorPrimary">@color/colorAccent</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Closes #39. Fixed dialog button color by creating a custom theme in which `colorPrimary` is set to the accent color.