### PR TITLE
#46 Intermittent crashes caused by stopped activities trying to open a dialog

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,6 +57,7 @@ android {
         it.buildConfigField("String", "SERVER_URL", getApiKey("serverURL"))
         it.buildConfigField("String", "SLACK_KEY", getApiKey("slackKey"))
         it.buildConfigField("String", "ADMOB_KEY", getApiKey("adMobKey"))
+        it.resValue("string", "ADMOB_KEY", getApiKey("adMobKey"))
         it.resValue("string", "DISPLAY_AD_ID", getApiKey("displayAdID"))
         it.resValue("string", "MAIN_AD_ID", getApiKey("mainAdID"))
         it.resValue("string", "SEARCH_AD_ID", getApiKey("searchAdID"))

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,8 +55,8 @@ android {
 
     buildTypes.each {
         it.buildConfigField("String", "SERVER_URL", getApiKey("serverURL"))
-        it.buildConfigField("String", "ADMOB_KEY", getApiKey("adMobKey"))
         it.buildConfigField("String", "SLACK_KEY", getApiKey("slackKey"))
+        it.resValue("string", "ADMOB_KEY", getApiKey("adMobKey"))
         it.resValue("string", "DISPLAY_AD_ID", getApiKey("displayAdID"))
         it.resValue("string", "MAIN_AD_ID", getApiKey("mainAdID"))
         it.resValue("string", "SEARCH_AD_ID", getApiKey("searchAdID"))

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,7 +56,7 @@ android {
     buildTypes.each {
         it.buildConfigField("String", "SERVER_URL", getApiKey("serverURL"))
         it.buildConfigField("String", "SLACK_KEY", getApiKey("slackKey"))
-        it.resValue("string", "ADMOB_KEY", getApiKey("adMobKey"))
+        it.buildConfigField("String", "ADMOB_KEY", getApiKey("adMobKey"))
         it.resValue("string", "DISPLAY_AD_ID", getApiKey("displayAdID"))
         it.resValue("string", "MAIN_AD_ID", getApiKey("mainAdID"))
         it.resValue("string", "SEARCH_AD_ID", getApiKey("searchAdID"))

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,6 @@ android {
         it.buildConfigField("String", "SERVER_URL", getApiKey("serverURL"))
         it.buildConfigField("String", "SLACK_KEY", getApiKey("slackKey"))
         it.buildConfigField("String", "ADMOB_KEY", getApiKey("adMobKey"))
-        it.resValue("string", "ADMOB_KEY", getApiKey("adMobKey"))
         it.resValue("string", "DISPLAY_AD_ID", getApiKey("displayAdID"))
         it.resValue("string", "MAIN_AD_ID", getApiKey("mainAdID"))
         it.resValue("string", "SEARCH_AD_ID", getApiKey("searchAdID"))

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -81,7 +81,7 @@
             android:value="true" />
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
-            android:value="@string/ADMOB_KEY" />
+            android:value="ca-app-pub-7378286993062620~3014364162" />
 
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -81,7 +81,7 @@
             android:value="true" />
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
-            android:value="ca-app-pub-7378286993062620~3014364162" />
+            android:value="@string/ADMOB_KEY" />
 
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"

--- a/app/src/main/java/com/a494studios/koreanconjugator/CustomApplication.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/CustomApplication.java
@@ -44,7 +44,7 @@ public class CustomApplication extends MultiDexApplication implements PurchasesU
         super.onCreate();
 
         // Setup ads
-        MobileAds.initialize(this, BuildConfig.ADMOB_KEY);
+        MobileAds.initialize(this);
 
         // Check preferences first, to save us a billing request
         Boolean prefAdFree = Utils.isAdFree(getApplicationContext());

--- a/app/src/main/java/com/a494studios/koreanconjugator/CustomApplication.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/CustomApplication.java
@@ -25,7 +25,6 @@ import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdView;
 import com.google.android.gms.ads.MobileAds;
 import com.google.firebase.analytics.FirebaseAnalytics;
-import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -91,10 +90,6 @@ public class CustomApplication extends MultiDexApplication implements PurchasesU
                 billingConnected = false;
             }
         });
-
-        // Disable Crashlytics for debug builds
-        FirebaseCrashlytics.getInstance()
-                .setCrashlyticsCollectionEnabled(!BuildConfig.DEBUG);
 
         // Setup Firebase Analytics
         Logger.initialize(FirebaseAnalytics.getInstance(this));

--- a/app/src/main/java/com/a494studios/koreanconjugator/CustomApplication.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/CustomApplication.java
@@ -25,6 +25,7 @@ import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.AdView;
 import com.google.android.gms.ads.MobileAds;
 import com.google.firebase.analytics.FirebaseAnalytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -90,6 +91,10 @@ public class CustomApplication extends MultiDexApplication implements PurchasesU
                 billingConnected = false;
             }
         });
+
+        // Disable Crashlytics for debug builds
+        FirebaseCrashlytics.getInstance()
+                .setCrashlyticsCollectionEnabled(!BuildConfig.DEBUG);
 
         // Setup Firebase Analytics
         Logger.initialize(FirebaseAnalytics.getInstance(this));

--- a/app/src/main/java/com/a494studios/koreanconjugator/CustomApplication.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/CustomApplication.java
@@ -44,7 +44,7 @@ public class CustomApplication extends MultiDexApplication implements PurchasesU
         super.onCreate();
 
         // Setup ads
-        MobileAds.initialize(this);
+        MobileAds.initialize(this, BuildConfig.ADMOB_KEY);
 
         // Check preferences first, to save us a billing request
         Boolean prefAdFree = Utils.isAdFree(getApplicationContext());

--- a/app/src/main/java/com/a494studios/koreanconjugator/CustomApplication.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/CustomApplication.java
@@ -31,7 +31,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 public class CustomApplication extends MultiDexApplication implements PurchasesUpdatedListener {
-    private static final String APP_ID = BuildConfig.ADMOB_KEY;
     private static final String SERVER_URL = com.a494studios.koreanconjugator.BuildConfig.SERVER_URL;
 
     private static boolean isAdFree = false;
@@ -45,7 +44,7 @@ public class CustomApplication extends MultiDexApplication implements PurchasesU
         super.onCreate();
 
         // Setup ads
-        MobileAds.initialize(this, APP_ID);
+        MobileAds.initialize(this);
 
         // Check preferences first, to save us a billing request
         Boolean prefAdFree = Utils.isAdFree(getApplicationContext());

--- a/app/src/main/java/com/a494studios/koreanconjugator/search/NoResultsFragment.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/search/NoResultsFragment.java
@@ -11,6 +11,7 @@ import androidx.fragment.app.DialogFragment;
 
 import com.a494studios.koreanconjugator.R;
 import com.a494studios.koreanconjugator.conjugator.ConjugatorActivity;
+import com.a494studios.koreanconjugator.utils.BaseDialogFragment;
 import com.a494studios.koreanconjugator.utils.Utils;
 
 import org.jetbrains.annotations.NotNull;
@@ -18,7 +19,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * A simple {@link DialogFragment} subclass.
  */
-public class NoResultsFragment extends DialogFragment implements DialogInterface.OnClickListener {
+public class NoResultsFragment extends BaseDialogFragment implements DialogInterface.OnClickListener {
 
     private static final String ARG_SEARCH_TERM = "search_term";
 

--- a/app/src/main/java/com/a494studios/koreanconjugator/settings/AddFavoriteFragment.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/settings/AddFavoriteFragment.java
@@ -4,7 +4,6 @@ import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
-import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.appcompat.app.AlertDialog;
 import android.text.Editable;
@@ -19,6 +18,9 @@ import android.widget.Toast;
 
 import com.a494studios.koreanconjugator.R;
 import com.a494studios.koreanconjugator.parsing.Favorite;
+import com.a494studios.koreanconjugator.utils.BaseDialogFragment;
+
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,7 +34,7 @@ import java.util.HashMap;
  * Use the {@link AddFavoriteFragment#newInstance} factory method to
  * create an instance of this fragment.
  */
-public class AddFavoriteFragment extends DialogFragment implements DialogInterface.OnClickListener {
+public class AddFavoriteFragment extends BaseDialogFragment implements DialogInterface.OnClickListener {
     public static final String ARG_NAMES = "NAMES";
     private static final int ITEM_LAYOUT = R.layout.item_spinner;
 
@@ -69,6 +71,7 @@ public class AddFavoriteFragment extends DialogFragment implements DialogInterfa
         }
     }
 
+    @NotNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         // Set up builder
@@ -148,7 +151,7 @@ public class AddFavoriteFragment extends DialogFragment implements DialogInterfa
     }
 
     @Override
-    public void onAttach(Context context) {
+    public void onAttach(@NotNull Context context) {
         super.onAttach(context);
         if (context instanceof AddFavoriteFragmentListener) {
             mListener = (AddFavoriteFragmentListener) context;

--- a/app/src/main/java/com/a494studios/koreanconjugator/utils/BaseDialogFragment.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/utils/BaseDialogFragment.java
@@ -1,0 +1,16 @@
+package com.a494studios.koreanconjugator.utils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentManager;
+
+public class BaseDialogFragment extends DialogFragment {
+
+    @Override
+    public void show(@NonNull FragmentManager manager, @Nullable String tag) {
+        if (!manager.isDestroyed() && !manager.isStateSaved()) {
+            super.show(manager, tag);
+        }
+    }
+}

--- a/app/src/main/java/com/a494studios/koreanconjugator/utils/ErrorDialogFragment.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/utils/ErrorDialogFragment.java
@@ -7,18 +7,18 @@ import android.os.Bundle;
 import androidx.fragment.app.DialogFragment;
 import androidx.appcompat.app.AlertDialog;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * A simple {@link DialogFragment} subclass.
  */
-public class ErrorDialogFragment extends DialogFragment implements DialogInterface.OnClickListener {
+public class ErrorDialogFragment extends BaseDialogFragment implements DialogInterface.OnClickListener {
 
     private static final String TITLE = "Error Occurred";
     private static final String MSG = "Something went wrong while loading this page, please contact support or try again later.";
     private static final String ARG_TITLE = "title";
     private static final String ARG_MSG = "message";
 
-    private String title;
-    private String msg;
     private DialogInterface.OnClickListener listener = null;
 
     public ErrorDialogFragment() {
@@ -41,11 +41,12 @@ public class ErrorDialogFragment extends DialogFragment implements DialogInterfa
         return frag;
     }
 
+    @NotNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        title = getArguments().getString(ARG_TITLE,TITLE);
-        msg = getArguments().getString(ARG_MSG,MSG);
+        String title = getArguments().getString(ARG_TITLE, TITLE);
+        String msg = getArguments().getString(ARG_MSG, MSG);
 
         builder.setTitle(title);
         builder.setMessage(msg);
@@ -69,7 +70,7 @@ public class ErrorDialogFragment extends DialogFragment implements DialogInterfa
     }
 
     @Override
-    public void onDismiss(DialogInterface dialog){
+    public void onDismiss(@NotNull DialogInterface dialog){
         super.onDismiss(dialog);
         if (listener != null) {
             listener.onClick(dialog, -1);

--- a/app/src/test/java/com/a494studios/koreanconjugator/settings/AddFavoriteFragmentTest.java
+++ b/app/src/test/java/com/a494studios/koreanconjugator/settings/AddFavoriteFragmentTest.java
@@ -1,0 +1,117 @@
+package com.a494studios.koreanconjugator.settings;
+
+import android.app.Dialog;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.EditText;
+import android.widget.Spinner;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.FragmentManager;
+
+import com.a494studios.koreanconjugator.R;
+import com.a494studios.koreanconjugator.parsing.Favorite;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+public class AddFavoriteFragmentTest {
+
+    private AddFavoritesFragmentActivity activity;
+    private HashMap<String,Boolean> conjData;
+
+    @Before
+    public void init() {
+        activity = Robolectric.buildActivity(AddFavoritesFragmentActivity.class)
+                .create()
+                .start()
+                .resume()
+                .get();
+
+        conjData = new HashMap<>();
+        conjData.put("Connective And", false);
+        conjData.put("Declarative Present", true);
+    }
+
+    @Test
+    public void btn_isDisabledUntilFormFilled() {
+        AddFavoriteFragment fragment = AddFavoriteFragment.newInstance(conjData);
+        FragmentManager fragmentManager = activity.getSupportFragmentManager();
+        fragment.show(fragmentManager, "tag");
+
+        AlertDialog dialog = (AlertDialog)fragment.getDialog();
+        assertTrue(dialog.isShowing());
+
+        Button btn = dialog.getButton(Dialog.BUTTON_POSITIVE);
+        assertFalse(btn.isEnabled());
+
+        EditText nameView = dialog.findViewById(R.id.addFav_name);
+        nameView.setText("foo");
+
+        assertTrue(btn.isEnabled());
+    }
+
+    @Test
+    public void form_canSubmitSimple() {
+        AddFavoriteFragment fragment = AddFavoriteFragment.newInstance(conjData);
+        FragmentManager fragmentManager = activity.getSupportFragmentManager();
+        fragment.show(fragmentManager, "tag");
+
+        AlertDialog dialog = (AlertDialog)fragment.getDialog();
+        assertTrue(dialog.isShowing());
+
+        EditText nameView = dialog.findViewById(R.id.addFav_name);
+        nameView.setText("foo");
+
+        Spinner spinner = dialog.findViewById(R.id.addFav_conjSpinner);
+        spinner.setSelection(0);
+
+        Button btn = dialog.getButton(Dialog.BUTTON_POSITIVE);
+        btn.performClick();
+
+        Favorite favorite = activity.getFavorite();
+        assertEquals("foo" , favorite.getName());
+        assertEquals("connective and", favorite.getConjugationName());
+        assertFalse(favorite.isHonorific());
+    }
+
+    @Test
+    public void form_canSubmitComplex() {
+        AddFavoriteFragment fragment = AddFavoriteFragment.newInstance(conjData);
+        FragmentManager fragmentManager = activity.getSupportFragmentManager();
+        fragment.show(fragmentManager, "tag");
+
+        AlertDialog dialog = (AlertDialog)fragment.getDialog();
+        assertTrue(dialog.isShowing());
+
+        EditText nameView = dialog.findViewById(R.id.addFav_name);
+        nameView.setText("foo");
+
+        Spinner spinner = dialog.findViewById(R.id.addFav_conjSpinner);
+        spinner.setSelection(1);
+
+        Spinner speechLevelSpinner = dialog.findViewById(R.id.addFav_speechLevelSpinner);
+        speechLevelSpinner.setSelection(1);
+
+        CheckBox checkBox = dialog.findViewById(R.id.addFav_checkbox);
+        checkBox.setChecked(true);
+
+        Button btn = dialog.getButton(Dialog.BUTTON_POSITIVE);
+        btn.performClick();
+
+        Favorite favorite = activity.getFavorite();
+        assertEquals("foo" , favorite.getName());
+        assertEquals("declarative present informal high", favorite.getConjugationName());
+        assertTrue(favorite.isHonorific());
+    }
+}

--- a/app/src/test/java/com/a494studios/koreanconjugator/settings/AddFavoritesFragmentActivity.java
+++ b/app/src/test/java/com/a494studios/koreanconjugator/settings/AddFavoritesFragmentActivity.java
@@ -1,0 +1,19 @@
+package com.a494studios.koreanconjugator.settings;
+
+import androidx.fragment.app.FragmentActivity;
+
+import com.a494studios.koreanconjugator.parsing.Favorite;
+
+class AddFavoritesFragmentActivity extends FragmentActivity implements AddFavoriteFragment.AddFavoriteFragmentListener {
+
+    private Favorite favorite;
+
+    public Favorite getFavorite() {
+        return favorite;
+    }
+
+    @Override
+    public void onFavoriteAdded(Favorite entry) {
+       favorite = entry;
+    }
+}


### PR DESCRIPTION
Closes #46.  I created a `BaseDialogFragment` that overrides the `open` method. This override only opens the dialog if the app is in a valid state (not destroyed and state not saved), otherwise is quietly ignores the method call. This base class was then used on all Dialog Fragments.

Also added tests for `NoResultsFragment` and fixed Admob deprecation warning.