### PR TITLE
Error handling for GraphQL API errors

### DIFF
--- a/app/src/main/java/com/a494studios/koreanconjugator/WordOfDayCard.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/WordOfDayCard.java
@@ -38,8 +38,14 @@ public class WordOfDayCard implements DisplayCardBody {
                     @Override
                     public void onNext(Response<WordOfTheDayQuery.Data> dataResponse) {
                         TextView textView = view.findViewById(R.id.wod_text);
-                        textView.setText(dataResponse.getData().wordOfTheDay.term);
 
+                        if(dataResponse.hasErrors()) {
+                            Utils.handleError(dataResponse.getErrors().get(0), (AppCompatActivity)context, null);
+                            textView.setText(R.string.wod_cant_connect);
+                            return;
+                        }
+
+                        textView.setText(dataResponse.getData().wordOfTheDay.term);
                         id = dataResponse.getData().wordOfTheDay.id;
                         cardView.disableButton(false);
                     }

--- a/app/src/main/java/com/a494studios/koreanconjugator/conjugations/ConjugationActivity.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/conjugations/ConjugationActivity.java
@@ -1,11 +1,13 @@
 package com.a494studios.koreanconjugator.conjugations;
 
 import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import android.annotation.SuppressLint;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.TextView;
@@ -16,6 +18,7 @@ import com.a494studios.koreanconjugator.fragment.ConjugationFragment;
 import com.a494studios.koreanconjugator.parsing.Server;
 import com.a494studios.koreanconjugator.utils.BaseActivity;
 import com.a494studios.koreanconjugator.utils.Utils;
+import com.apollographql.apollo.api.Error;
 
 import java.util.List;
 
@@ -71,6 +74,9 @@ public class ConjugationActivity extends BaseActivity {
 
     @SuppressLint("CheckResult")
     private void getConjugations(String stem, boolean honorific, boolean isAdj, Boolean regular) {
+        AppCompatActivity activity = this;
+        DialogInterface.OnClickListener listener = (dialogInterface, i) -> this.finish();
+
         ConjugationObserver observer = new ConjugationObserver(new ConjugationObserver.ConjugationObserverListener() {
             @Override
             public void onDataReceived(List<List<ConjugationFragment>> conjugations) {
@@ -82,8 +88,12 @@ public class ConjugationActivity extends BaseActivity {
             @Override
             public void onError(Throwable e) {
                 e.printStackTrace();
-                Utils.handleError(e, ConjugationActivity.this,4,
-                        (dialogInterface, i) -> ConjugationActivity.this.finish());
+                Utils.handleError(e, activity,4, listener);
+            }
+
+            @Override
+            public void onApiError(Error e) {
+                Utils.handleError(e, activity, listener);
             }
         });
 

--- a/app/src/main/java/com/a494studios/koreanconjugator/conjugations/ConjugationObserver.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/conjugations/ConjugationObserver.java
@@ -2,6 +2,7 @@ package com.a494studios.koreanconjugator.conjugations;
 
 import com.a494studios.koreanconjugator.ConjugationQuery;
 import com.a494studios.koreanconjugator.fragment.ConjugationFragment;
+import com.apollographql.apollo.api.Error;
 import com.apollographql.apollo.api.Response;
 
 import java.util.ArrayList;
@@ -19,7 +20,8 @@ public class ConjugationObserver extends DisposableObserver<Response<Conjugation
 
     @Override
     public void onNext(Response<ConjugationQuery.Data> response) {
-        if(response.getData() == null) {
+        if(response.hasErrors()) {
+            listener.onApiError(response.getErrors().get(0));
             return;
         }
 
@@ -58,6 +60,8 @@ public class ConjugationObserver extends DisposableObserver<Response<Conjugation
         void onDataReceived(List<List<ConjugationFragment>> conjugations);
 
         void onError(Throwable e);
+
+        void onApiError(Error e);
     }
 }
 

--- a/app/src/main/java/com/a494studios/koreanconjugator/conjugator/ConjugatorActivity.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/conjugator/ConjugatorActivity.java
@@ -26,6 +26,7 @@ import com.a494studios.koreanconjugator.fragment.ConjugationFragment;
 import com.a494studios.koreanconjugator.parsing.Server;
 import com.a494studios.koreanconjugator.utils.BaseActivity;
 import com.a494studios.koreanconjugator.utils.Utils;
+import com.apollographql.apollo.api.Error;
 import com.apollographql.apollo.api.Response;
 
 import java.util.List;
@@ -183,6 +184,12 @@ public class ConjugatorActivity extends BaseActivity implements AdapterView.OnIt
             public void onError(Throwable e) {
                 e.printStackTrace();
                 Utils.handleError(e, ConjugatorActivity.this,10,
+                        (dialogInterface, i) -> ConjugatorActivity.this.finish());
+            }
+
+            @Override
+            public void onApiError(Error e) {
+                Utils.handleError(e, ConjugatorActivity.this,
                         (dialogInterface, i) -> ConjugatorActivity.this.finish());
             }
         });

--- a/app/src/main/java/com/a494studios/koreanconjugator/display/DisplayActivity.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/display/DisplayActivity.java
@@ -6,6 +6,7 @@ import androidx.appcompat.app.ActionBar;
 import android.content.Intent;
 import android.os.Bundle;
 
+import android.util.Pair;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -30,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.reactivex.Observable;
+import io.reactivex.functions.Function;
 
 public class DisplayActivity extends BaseActivity {
 
@@ -88,13 +90,17 @@ public class DisplayActivity extends BaseActivity {
                 .concatMap(dataResponse -> {
                     assert dataResponse.getData() != null;
 
+                    if(dataResponse.hasErrors()) {
+                        Utils.displayErrorDialog( DisplayActivity.this,"Timeout","Try again later", (dialogInterface, i) -> DisplayActivity.this.finish());
+                        return Observable.just(new Pair<EntryQuery.Entry,FavoritesQuery.Data>(null, null));
+                    }
+
                     entry = dataResponse.getData().entry();
                     boolean isAdj = entry.pos().equals("Adjective");
                     Boolean regular = entry.regular();
-                    observer.setEntry(entry);
 
                     if (!entry.pos().equals("Verb") && !isAdj) {
-                        return Observable.just("");
+                        return Observable.just(new Pair<EntryQuery.Entry,FavoritesQuery.Data>(entry, null));
                     }
 
                     // Log select content event
@@ -111,12 +117,9 @@ public class DisplayActivity extends BaseActivity {
                             .toList()
                             .blockingGet();
 
-                    return Server.doFavoritesQuery(entry.term(),  isAdj, regular, conjugations, app);
+                    return Server.doFavoritesQuery(entry.term(),  isAdj, regular, conjugations, app)
+                            .map((Function<Response<FavoritesQuery.Data>, Pair<? super EntryQuery.Entry, ?>>) res -> new Pair<>(entry, res.getData()));
                 })
-                // If no conjugations, create an empty list to prevent a null exception
-                .map(o -> o instanceof String
-                        ? new FavoritesQuery.Data(new ArrayList<>())
-                        : ((Response<FavoritesQuery.Data>) o).getData())
                 .subscribeWith(observer);
 
         LinearLayout linearLayout = findViewById(R.id.disp_root);

--- a/app/src/main/java/com/a494studios/koreanconjugator/display/DisplayActivity.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/display/DisplayActivity.java
@@ -91,7 +91,7 @@ public class DisplayActivity extends BaseActivity {
                     assert dataResponse.getData() != null;
 
                     if(dataResponse.hasErrors()) {
-                        Utils.displayErrorDialog( DisplayActivity.this,"Timeout","Try again later", (dialogInterface, i) -> DisplayActivity.this.finish());
+                        Utils.handleError(dataResponse.getErrors().get(0), this, (dialogInterface, i) -> this.finish());
                         return Observable.just(new Pair<EntryQuery.Entry,FavoritesQuery.Data>(null, null));
                     }
 

--- a/app/src/main/java/com/a494studios/koreanconjugator/display/DisplayObserver.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/display/DisplayObserver.java
@@ -52,7 +52,7 @@ public class DisplayObserver extends DisposableObserver<Pair<? super EntryQuery.
         }
         EntryQuery.Entry entry = (EntryQuery.Entry) data.first;
 
-        // Favorites, hide the card and skip if there are none
+        // Favorites, hide the card if the entry's not a verb/adj
         String pos = entry.pos();
         if (data.second == null) {
             conjugations.setVisibility(View.GONE);

--- a/app/src/main/java/com/a494studios/koreanconjugator/display/DisplayObserver.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/display/DisplayObserver.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import io.reactivex.Observable;
 import io.reactivex.observers.DisposableObserver;
 
-public class DisplayObserver extends DisposableObserver<FavoritesQuery.Data> {
+public class DisplayObserver extends DisposableObserver<Pair<? super EntryQuery.Entry, ?>> {
     private DisplayCardView displayCardView;
     private DisplayCardView note;
     private DisplayCardView examples;
@@ -32,7 +32,6 @@ public class DisplayObserver extends DisposableObserver<FavoritesQuery.Data> {
     private DisplayCardView antonyms;
     private DisplayCardView conjugations;
 
-    private EntryQuery.Entry entry;
     private DisplayObserverInterface listener;
 
     DisplayObserver(View rootView, DisplayObserverInterface listener) {
@@ -45,18 +44,20 @@ public class DisplayObserver extends DisposableObserver<FavoritesQuery.Data> {
         this.listener = listener;
     }
 
-    public void setEntry(EntryQuery.Entry entry) {
-        this.entry = entry;
-    }
-
     @SuppressLint("CheckResult")
     @Override
-    public void onNext(FavoritesQuery.Data favData) {
+    public void onNext(Pair<? super EntryQuery.Entry, ?> data) {
+        if(data.first == null) {
+            return;
+        }
+        EntryQuery.Entry entry = (EntryQuery.Entry) data.first;
+
         // Favorites, hide the card and skip if there are none
         String pos = entry.pos();
-        if (!pos.equals("Adjective") && !pos.equals("Verb")) {
+        if (data.second == null) {
             conjugations.setVisibility(View.GONE);
         } else {
+            FavoritesQuery.Data favData = (FavoritesQuery.Data) data.second;
             List<FavoritesQuery.FavConjugation> conjugations = favData.favConjugations();
             boolean isAdj = pos.equals("Adjective");
             Boolean regular = entry.regular();
@@ -85,10 +86,10 @@ public class DisplayObserver extends DisposableObserver<FavoritesQuery.Data> {
                             FavoritesQuery.FavConjugation conjugation = (FavoritesQuery.FavConjugation) pair.second;
 
                             ConjugationFragment fragment = conjugation.fragments().conjugationFragment();
-                            Map.Entry<String, ConjugationFragment> entry =
+                            Map.Entry<String, ConjugationFragment> conjEntry =
                                     new AbstractMap.SimpleEntry<>(f.getName(), fragment);
 
-                            card.addConjugation(entry, favorites.indexOf(f));
+                            card.addConjugation(conjEntry, favorites.indexOf(f));
                         }
                     });
         }

--- a/app/src/main/java/com/a494studios/koreanconjugator/parsing/Server.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/parsing/Server.java
@@ -55,8 +55,7 @@ public class Server {
 
         return Rx2Apollo.from(call)
                 .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .filter((dataResponse) -> dataResponse.getData() != null);
+                .observeOn(AndroidSchedulers.mainThread());
     }
 
     public static Observable<Response<EntryQuery.Data>> doEntryQuery(final String id, CustomApplication app) {
@@ -98,7 +97,6 @@ public class Server {
         return Rx2Apollo.from(call)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .filter((dataResponse) -> dataResponse.getData() != null)
                 .doAfterTerminate(() -> idler.decrement());
     }
 
@@ -146,7 +144,6 @@ public class Server {
         return Rx2Apollo.from(call)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .filter((dataResponse -> dataResponse.getData() != null))
                 .doAfterTerminate(() -> idler.decrement());
     }
 

--- a/app/src/main/java/com/a494studios/koreanconjugator/utils/Utils.java
+++ b/app/src/main/java/com/a494studios/koreanconjugator/utils/Utils.java
@@ -21,6 +21,7 @@ import com.android.billingclient.api.BillingFlowParams;
 import com.android.billingclient.api.BillingResult;
 import com.android.billingclient.api.SkuDetails;
 import com.android.billingclient.api.SkuDetailsParams;
+import com.apollographql.apollo.api.Error;
 import com.apollographql.apollo.exception.ApolloNetworkException;
 import com.eggheadgames.aboutbox.AboutConfig;
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
@@ -211,6 +212,18 @@ public class Utils {
                 System.out.println("Error getting SKU Details: " + billingResult.getResponseCode());
             }
         });
+    }
+
+    public static void handleError(Error error, AppCompatActivity context, DialogInterface.OnClickListener listener){
+        ErrorDialogFragment fragment = ErrorDialogFragment.newInstance("Something went wrong", error.getMessage());
+
+        if(listener != null){
+            fragment.setListener(listener);
+        }
+        context.getSupportFragmentManager()
+                .beginTransaction()
+                .add(fragment,"frag_alert")
+                .commitAllowingStateLoss();
     }
 
     public static void handleError(Throwable error, AppCompatActivity context, int errorCode, DialogInterface.OnClickListener listener){

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,7 @@
     <string name="menu_ad_free">Remove Ads</string>
     <string name="conj_seperator">:</string>
     <string name="empty_favorites">You don\'t have any favorites. Click on favorites in settings to make some.</string>
+    <string name="wod_cant_connect">Can\'t connect to server</string>
     <!-- Suggestions -->
     <string name="suggestion_submit">Submit</string>
     <string name="menu_add">Add suggestion</string>


### PR DESCRIPTION
Added error handling for GraphQL errors returned in the response. These response are still considered successfull, so they go to `onNext` instead of `onError`.